### PR TITLE
Fixed the handling of imports

### DIFF
--- a/calculateUserAndProblemSkills.py
+++ b/calculateUserAndProblemSkills.py
@@ -326,10 +326,10 @@ def getAllImports(a):
     for child in ast.walk(a):
         if type(child) == ast.Import:
             for alias in child.names:
-                imports.add(alias.asname if alias.asname != None else alias.name)
+                imports.add(alias.name)
         elif type(child) == ast.ImportFrom:
             for alias in child.names: # these are all functions
-                imports.add(alias.asname if alias.asname != None else alias.name)
+                imports.add(child.module + "." + alias.name)
 
 
     result = {}


### PR DESCRIPTION
1. Alias names are ignored in imports, that is

       import module as alias

   is handled no differently from

       import module

2. Besides, names imported from a module via 'from module import ...'
   are now registered in the imports section with the module name
   prepended to them. For example, if previously

       from sys import argv

   resulted in an 'argv' entry being added to the 'imports' collection,
   now it is added as 'sys.argv'.