### PR TITLE
Defined functions are dropped from 'functions'

### DIFF
--- a/calculateUserAndProblemSkills.py
+++ b/calculateUserAndProblemSkills.py
@@ -314,6 +314,14 @@ def getFuncCalls(tree):
       result[item] += 1
     return dict(result)
 
+def getFuncDefs(tree):
+    r = set()
+    for node in ast.walk(tree):
+        if type(node) is ast.FunctionDef:
+            r.add(node.name)
+
+    return list(r)
+
 ################################################################################
 # Imports
 ################################################################################
@@ -344,13 +352,19 @@ def getAllImports(a):
 def code_features(src):
   tree = ast.parse(src)
 
+  funcCalls = getFuncCalls(tree)
   result = {
             "statements":  getAllStatements(tree),
-            "functions":   getFuncCalls(tree),
+            "functions":   funcCalls,
             "imports":     getAllImports(tree),
             "expressions": getAllExpr(tree),
             "constructs" : getAllConstructs(tree)
            }
+
+  definedFunctions = getFuncDefs(tree)
+  for df in definedFunctions:
+      if df in funcCalls:
+        del funcCalls[df]
 
   return result
 
@@ -425,7 +439,7 @@ defaultGetResponse = """
 </div>
 <script src="https://unpkg.com/vue"></script>
 <script>
-  
+
   var app = new Vue({
     el: "#app",
     data:{


### PR DESCRIPTION
Function calls are registered in 'functions' only if those names are not def'ed in the analyzed piece of code. This is done as a workaround for [issue#328](https://github.com/NUS-ALSET/achievements/issues/328) of the [Achievements repository](https://github.com/NUS-ALSET/achievements).
However, since no static code analysis is actually performed, this can lead to both
false positives and false negatives.

An example of a false positive:

    def foo():
        pass

    bar = foo
    bar()

The function call `bar()` on the last line actually refers to the
function object defined in the same module, however `bar` will appear
in the 'functions' features.

An example of a false negative:

    def join():
        pass

    s = "".join(some_list)

The function call `.join()` has no relation to the function defined
above it, however it will be removed from the 'functions' features.